### PR TITLE
[FIX/#30]해커뉴스 소스 응답 통일

### DIFF
--- a/src/main/java/com/nova/nova_server/domain/post/parser/HackerNewsParser.java
+++ b/src/main/java/com/nova/nova_server/domain/post/parser/HackerNewsParser.java
@@ -39,10 +39,8 @@ public class HackerNewsParser {
                 String title = item.has("title") ? item.get("title").asText() : null;
                 String author = item.has("by") ? item.get("by").asText() : null;
 
-                // source 필드 확인 (있으면 가져오고 없으면 null)
-                String source = item.has("source") && !item.get("source").isNull()
-                        ? item.get("source").asText()
-                        : null;
+                // source 필드 하드코딩
+                String source = "Hacker News";
 
                 // text 필드에서 content 추출
                 String content = "";


### PR DESCRIPTION

## 📌 관련 이슈
- #30 

## ✨ PR 세부 내용
<img width="724" height="492" alt="image" src="https://github.com/user-attachments/assets/86424d11-8330-4c40-9967-3755d8b0ddd4" />
해커뉴스 소스 응답 통일했습니다

## 💬 **리뷰 요청 사항**


## ✅ 체크리스트

- [ ] 빌드 및 테스트 통과
- [ ] 주요 기능 정상 동작

