### PR TITLE
[FEAT/#69] 피드 조회 시 근거를 파싱하여 응답

### DIFF
--- a/src/main/java/com/nova/nova_server/domain/feed/converter/FeedConverter.java
+++ b/src/main/java/com/nova/nova_server/domain/feed/converter/FeedConverter.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -41,7 +42,7 @@ public class FeedConverter {
                 .author(cardNews.getAuthor())
                 .publishedAt(cardNews.getPublishedAt().atOffset(ZoneOffset.UTC))
                 .summary(cardNews.getSummary())
-                .evidence(cardNews.getEvidence())
+                .evidence(splitEvidence(cardNews.getEvidence()))
                 .originalUrl(cardNews.getOriginalUrl())
                 .siteName(cardNews.getSourceSiteName())
                 .keywords(cardNews.getKeywords().stream()
@@ -49,6 +50,14 @@ public class FeedConverter {
                         .toList())
                 .saved(saved)
                 .build();
+    }
+
+    private List<String> splitEvidence(String evidence) {
+        if (evidence == null || evidence.isEmpty()) {
+            return List.of();
+        }
+
+        return List.of(evidence.split("\\n"));
     }
 
     private LocalDateTime toUtcLocalDateTime(OffsetDateTime offsetDateTime) {

--- a/src/main/java/com/nova/nova_server/domain/feed/dto/FeedResponse.java
+++ b/src/main/java/com/nova/nova_server/domain/feed/dto/FeedResponse.java
@@ -28,8 +28,8 @@ public record FeedResponse(
         @Schema(description = "요약 내용", example = "Nova는 개발자를 위한 AI 트렌드 인사이트 플랫폼으로, 최신 AI 기술과 트렌드를 한눈에 파악할 수 있는 서비스를 제공합니다.")
         String summary,
 
-        @Schema(description = "근거", example = "주기적으로 최신 글을 확인하고 카드뉴스를 생성합니다.")
-        String evidence,
+        @Schema(description = "근거 목록", example = "[\"주기적으로 최신 글을 확인하고 카드뉴스를 생성합니다.\"]")
+        List<String> evidence,
 
         @Schema(description = "원본 URL", example = "https://github.com/NOVA-9th/nova-be")
         String originalUrl,


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[작업타입/#이슈번호] 작업 요약
-->

## 📌 관련 이슈

- #69

## ✨ PR 세부 내용

<!-- 이번 PR에서 작업한 내용 및 주요 변경사항 (이미지 첨부 가능) -->
<!-- 구현 기능 요약 -->
<!-- 주요 변경사항 -->

‐ 카드뉴스 생성 배치 작업에서 근거를 개행으로 구분하여 기록함에 따라
피드 응답 시 해당 내용 파싱하여 리스트로 응답하도록 변경

## 💬 **리뷰 요청 사항**

<!-- 리뷰를 요청하고 싶은 내용 -->
<!-- 리뷰어가 알아야 할 사항 -->
<!-- 논의가 필요한 사항 -->

## ✅ 체크리스트

- [x] 빌드 및 테스트 통과
- [x] 주요 기능 정상 동작

