### PR TITLE
[FEAT/#86] 유저 관심 키워드 조회 API 추가

### DIFF
--- a/src/main/java/com/nova/nova_server/domain/member/controller/MemberInfoController.java
+++ b/src/main/java/com/nova/nova_server/domain/member/controller/MemberInfoController.java
@@ -1,14 +1,18 @@
 package com.nova.nova_server.domain.member.controller;
 
 import com.nova.nova_server.domain.member.dto.*;
+import com.nova.nova_server.domain.member.error.MemberErrorCode;
 import com.nova.nova_server.domain.member.service.MemberService;
 import com.nova.nova_server.global.apiPayload.ApiResponse;
+import com.nova.nova_server.global.apiPayload.exception.NovaException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/members")
@@ -70,6 +74,25 @@ public class MemberInfoController {
 
         memberService.updateMemberPersonalization(memberId, request);
         return ApiResponse.success(null);
+    }
+
+    @Operation(summary = "관심 키워드 조회", description = "사용자의 관심 키워드 목록을 조회합니다.")
+    @GetMapping("/{member_id}/keywords")
+    public ApiResponse<MemberPreferKeywordResponseDto> getMemberKeywords(
+            @Parameter(description = "사용자 ID")
+            @PathVariable("member_id") Long memberId,
+            @AuthenticationPrincipal Long authenticatedMemberId
+    ) {
+        if (!authenticatedMemberId.equals(memberId)) {
+            throw new NovaException(MemberErrorCode.MEMBER_READ_FORBIDDEN);
+        }
+
+        List<String> keywords = memberService.getMemberKeywords(memberId);
+        return ApiResponse.success(MemberPreferKeywordResponseDto.builder()
+                .totalCount(keywords.size())
+                .keywords(keywords)
+                .build()
+        );
     }
 
     @Operation(summary = "연결된 계정 조회", description = "소셜 로그인 등 사용자와 연결된 계정 정보를 조회합니다.")

--- a/src/main/java/com/nova/nova_server/domain/member/dto/MemberPreferKeywordResponseDto.java
+++ b/src/main/java/com/nova/nova_server/domain/member/dto/MemberPreferKeywordResponseDto.java
@@ -1,0 +1,17 @@
+package com.nova.nova_server.domain.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@Schema(description = "사용자 관심 키워드 응답")
+public record MemberPreferKeywordResponseDto(
+        @Schema(description = "관심 키워드 총 개수", example = "5")
+        long totalCount,
+
+        @Schema(description = "관심 키워드 목록", example = "[\"Spring Boot\", \"React\", \"AI\"]")
+        List<String> keywords
+) {
+}

--- a/src/main/java/com/nova/nova_server/domain/member/error/MemberErrorCode.java
+++ b/src/main/java/com/nova/nova_server/domain/member/error/MemberErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum MemberErrorCode implements ErrorCode {
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4040", "존재하지 않는 사용자입니다."),
+    MEMBER_READ_FORBIDDEN(HttpStatus.FORBIDDEN, "MEMBER4030", "본인의 정보만 조회할 수 있습니다."),
     MEMBER_FORBIDDEN(HttpStatus.FORBIDDEN, "MEMBER4030", "본인의 정보만 수정할 수 있습니다."),
     MEMBER_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "MEMBER4000", "이름은 필수 입력 항목입니다.");
 

--- a/src/main/java/com/nova/nova_server/domain/member/service/MemberService.java
+++ b/src/main/java/com/nova/nova_server/domain/member/service/MemberService.java
@@ -2,20 +2,19 @@ package com.nova.nova_server.domain.member.service;
 
 import com.nova.nova_server.domain.interest.entity.Interest;
 import com.nova.nova_server.domain.interest.repository.InterestRepository;
+import com.nova.nova_server.domain.keyword.entity.Keyword;
 import com.nova.nova_server.domain.keyword.error.KeywordErrorCode;
+import com.nova.nova_server.domain.keyword.repository.KeywordRepository;
 import com.nova.nova_server.domain.member.dto.*;
 import com.nova.nova_server.domain.member.entity.Member;
-import com.nova.nova_server.domain.keyword.entity.Keyword;
-import com.nova.nova_server.domain.keyword.repository.KeywordRepository;
 import com.nova.nova_server.domain.member.entity.MemberPreferInterest;
 import com.nova.nova_server.domain.member.entity.MemberPreferKeyword;
 import com.nova.nova_server.domain.member.error.MemberErrorCode;
 import com.nova.nova_server.domain.member.repository.MemberPreferInterestRepository;
 import com.nova.nova_server.domain.member.repository.MemberPreferKeywordRepository;
-import com.nova.nova_server.domain.member.repository.MemberRepository;
 import com.nova.nova_server.domain.member.repository.MemberProfileImageRepository;
+import com.nova.nova_server.domain.member.repository.MemberRepository;
 import com.nova.nova_server.global.apiPayload.exception.NovaException;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -111,6 +110,10 @@ public class MemberService {
         // 키워드
         List<String> keywordNames = memberPersonalizationDto.keywords();
         updateMemberKeywords(member, keywordNames);
+    }
+
+    public List<String> getMemberKeywords(Long memberId) {
+        return memberPreferKeywordRepository.findKeywordNamesByMemberId(memberId);
     }
 
     private void updateMemberInterests(Member member, List<Long> interestIds) {


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[작업타입/#이슈번호] 작업 요약
-->

## 📌 관련 이슈

- #86

## ✨ PR 세부 내용

<!-- 이번 PR에서 작업한 내용 및 주요 변경사항 (이미지 첨부 가능) -->
<!-- 구현 기능 요약 -->
<!-- 주요 변경사항 -->

- 로그인한 유저의 관심 키워드만 조회하는 API 추가

## 💬 **리뷰 요청 사항**

<!-- 리뷰를 요청하고 싶은 내용 -->
<!-- 리뷰어가 알아야 할 사항 -->
<!-- 논의가 필요한 사항 -->

## ✅ 체크리스트

- [x] 빌드 및 테스트 통과
- [x] 주요 기능 정상 동작

