### PR TITLE
[FEAT/#100] 피드검색 api 구현

### DIFF
--- a/src/main/java/com/nova/nova_server/domain/cardNews/dto/CardNewsSearchCondition.java
+++ b/src/main/java/com/nova/nova_server/domain/cardNews/dto/CardNewsSearchCondition.java
@@ -17,6 +17,7 @@ public record CardNewsSearchCondition(
         List<CardType> type,
         List<String> keywords,
         Boolean saved,
-        Pageable pageable
-) {
+        String searchKeyword,
+        Boolean hidden,
+        Pageable pageable) {
 }

--- a/src/main/java/com/nova/nova_server/domain/feed/converter/FeedConverter.java
+++ b/src/main/java/com/nova/nova_server/domain/feed/converter/FeedConverter.java
@@ -32,6 +32,8 @@ public class FeedConverter {
                 .type(request.type())
                 .keywords(request.keywords())
                 .saved(request.saved())
+                .searchKeyword(request.searchKeyword())
+                .hidden(request.hidden())
                 .pageable(toPageable(request.page(), request.size()))
                 .build();
     }

--- a/src/main/java/com/nova/nova_server/domain/feed/dto/FeedRequest.java
+++ b/src/main/java/com/nova/nova_server/domain/feed/dto/FeedRequest.java
@@ -9,28 +9,23 @@ import java.util.List;
 
 @Schema(description = "피드 조회 요청 파라미터")
 public record FeedRequest(
-        @Schema(description = "정렬 기준, LATEST 또는 RELEVANCE", example = "RELEVANCE", defaultValue = "LATEST")
-        FeedSort sort,
+        @Schema(description = "정렬 기준, LATEST 또는 RELEVANCE", example = "RELEVANCE", defaultValue = "LATEST") FeedSort sort,
 
-        @Schema(description = "업로드 기간 (시작), UTC 기준, ISO 8601 형식, 경계값 포함", example = "2026-01-01T15:00:00Z")
-        OffsetDateTime startDate,
+        @Schema(description = "업로드 기간 (시작), UTC 기준, ISO 8601 형식, 경계값 포함", example = "2026-01-01T15:00:00Z", defaultValue = "2026-01-01T15:00:00Z") OffsetDateTime startDate,
 
-        @Schema(description = "업로드 기간 (종료), UTC 기준, ISO 8601 형식, 경계값 미포함", example = "2026-01-31T15:00:00Z")
-        OffsetDateTime endDate,
+        @Schema(description = "업로드 기간 (종료), UTC 기준, ISO 8601 형식, 경계값 미포함", example = "2026-02-28T15:00:00Z", defaultValue = "2026-02-28T15:00:00Z") OffsetDateTime endDate,
 
-        @Schema(description = "카드 유형, NEWS, JOB, COMMUNITY 중 0개 이상 선택", example = "NEWS")
-        List<CardType> type,
+        @Schema(description = "카드 유형, NEWS, JOB, COMMUNITY 중 0개 이상 선택", example = "NEWS") List<CardType> type,
 
-        @Schema(description = "키워드 필터", example = "Spring Boot")
-        List<String> keywords,
+        @Schema(description = "키워드 필터", example = "Spring Boot") List<String> keywords,
 
-        @Schema(description = "페이지 번호", example = "1", defaultValue = "1")
-        Integer page,
+        @Schema(description = "페이지 번호", example = "1", defaultValue = "1") Integer page,
 
-        @Schema(description = "페이지 크기", example = "10", defaultValue = "10")
-        Integer size,
+        @Schema(description = "페이지 크기", example = "10", defaultValue = "10") Integer size,
 
-        @Schema(description = "저장한 글만 조회할지 여부", example = "false")
-        Boolean saved
-) {
+        @Schema(description = "저장한 글만 조회할지 여부", example = "false") Boolean saved,
+
+        @Schema(description = "검색 키워드 (제목 또는 본문)", example = "Spring", defaultValue = "") String searchKeyword,
+
+        @Schema(description = "숨김 처리된 글 조회 여부 (true: 숨긴 글만, false: 숨기지 않은 글만)", example = "false", defaultValue = "false") Boolean hidden) {
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[작업타입/#이슈번호] 작업 요약
-->

## 📌 관련 이슈

- #100 

## ✨ PR 세부 내용
- 기존 피드조회 API에 searchkeyword 파라미터를 추가하여 검색기능이 동작하도록 개선했습니다. <br>
<img width="650" alt="image" src="https://github.com/user-attachments/assets/f557b44c-f4b9-43bc-90a9-13a7b3bf57ac" />

<!-- 이번 PR에서 작업한 내용 및 주요 변경사항 (이미지 첨부 가능) -->
<!-- 구현 기능 요약 -->
<!-- 주요 변경사항 -->

## 💬 **리뷰 요청 사항**
- 프론트측의 긴급요청으로 피드검색 api 구현했습니다.
- 코드에 이상없을시 머지 후 배포해주시길 바랍니다. 일단 프론트분께는 local로 서버를 열어 작업하라고 언질드렸습니다.
<!-- 리뷰를 요청하고 싶은 내용 -->
<!-- 리뷰어가 알아야 할 사항 -->
<!-- 논의가 필요한 사항 -->

## ✅ 체크리스트

- [x] 빌드 및 테스트 통과
- [x] 주요 기능 정상 동작

